### PR TITLE
Use enter/exit instead of bind

### DIFF
--- a/index.js
+++ b/index.js
@@ -2,11 +2,14 @@ module.exports = function create(opts) {
   if (!opts.ns) {
     throw new Error('opts.ns is needed!');
   }
-
+  const ns = opts.ns;
   return function* (next) {
-    yield new Promise(opts.ns.bind(function (resolve) {
-      resolve();
-    }));
-    yield* next;
+    const ctx = ns.createContext();
+    ns.enter(ctx);
+    try {
+      yield* next;
+    } finally {
+      ns.exit(ctx);
+    }
   };
 };


### PR DESCRIPTION
I was having some anomalous behaviour (e.g. using Mongoose middleware) where the context would suddenly be empty. To be completely honest I don't exactly have a lot of knowledge about how CLS works, but your tests still pass and everything I had that was acting funky started behaving with these changes. Thoughts?
